### PR TITLE
Support overriding color variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ All you have to do is change your `assets/stylesheets/active_admin.scss`:
 @import 'formadmin/formadmin';
 ```
 
+### Overriding colors
+You can override the default colors (as defined in `app/assets/stylesheets/formadmin/core/_settings.scss`) by setting the color variable in your `assets/stylesheets/active_admin.scss` before `formadmin` is loaded.
+
+For example, to change the primary color, use:
+
+```sass
+$primary-color: #024500;
+@import 'formadmin/formadmin';
+```
+
 ## Video
 
 ![Formadmin](formadmin.gif)

--- a/app/assets/stylesheets/formadmin/core/_settings.scss
+++ b/app/assets/stylesheets/formadmin/core/_settings.scss
@@ -69,26 +69,26 @@ $gray:   #3f3f3f;
 $black:  #000000;
 
 //--- Emotive ---//
-$positive-color: $green;
-$negative-color: $red;
-$info-color:     $blue;
-$warning-color:  $yellow;
+$positive-color: $green !default;
+$negative-color: $red !default;
+$info-color:     $blue !default;
+$warning-color:  $yellow !default;
 
 //--- Theme ---//
-$primary-color:   #4d5256;
-$secondary-color: $silver;
+$primary-color:   #4d5256 !default;
+$secondary-color: $silver !default;
 
 //--- Page ---//
-$background-color: #eeeeee;
-$text-color:       $gray;
+$background-color: #eeeeee !default;
+$text-color:       $gray !default;
 
 //--- Highlighting ---//
-$highlight-background: rgba($primary-color, 0.5);
-$highlight-color:      $white;
+$highlight-background: rgba($primary-color, 0.5) !default;
+$highlight-color:      $white !default;
 
 
 //-------------//
 //   Borders   //
 //-------------//
-$radius:          4px;
-$circular-radius: 500rem;
+$radius:          4px !default;
+$circular-radius: 500rem !default;


### PR DESCRIPTION
I wanted to be able to use `formadmin` with custom colors so I needed a way to override the color variables as defined in `app/assets/stylesheets/formadmin/core/_settings.scss`. By using `!default` on these, if these are already defined, `formadmin` won't redefine them, meaning you can set these variables before importing `formadmin`.

I've also updated the readme to provide details about overriding colors.

Please let me know any feedback you've got, happy to make fixes to the change.

Thanks!