### PR TITLE
Style for error message

### DIFF
--- a/app/assets/stylesheets/formadmin/components/_form.scss
+++ b/app/assets/stylesheets/formadmin/components/_form.scss
@@ -283,6 +283,18 @@ form {
       padding-left: 0;
     }
   }
+  ul{
+    &.errors {
+      font-size: 14px;
+      border: 2px solid $red;
+      border-radius: 5px;
+      padding: 9px;
+      background: rgba($red,.5);
+      color: $white;
+      font-weight: bold;
+      margin: 10px 0;
+    }
+  }
 }
 
 // Sidebar

--- a/app/assets/stylesheets/formadmin/core/_settings.scss
+++ b/app/assets/stylesheets/formadmin/core/_settings.scss
@@ -42,7 +42,7 @@ $largest-tablet-screen:     screen((max-width: $maximum-page-width - 1));
 $font-smoothing: antialiased;
 
 //--- Page ---//
-$font-size:   16px;
+$font-size:   12px;
 $font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
 $font-weight: normal;
 $line-height: 1.5;

--- a/app/assets/stylesheets/formadmin/layouts/_header.scss
+++ b/app/assets/stylesheets/formadmin/layouts/_header.scss
@@ -13,6 +13,7 @@
   z-index: 10;
 
   .site_title {
+    font-size: 18px;
     font-weight: bold;
     margin: 0 20px 0 0;
     padding: 0 30px;


### PR DESCRIPTION
Added css to f.semantic_errors tag of active admin. 
```
form do |f|
    f.semantic_errors *f.object.errors.keys
end
```

## Without new css
![Without new css](http://i.imgur.com/XJTO7O9.png)

## With new css style
![With new csss](http://i.imgur.com/FvLYl0I.png)


