### PR TITLE
Remove datepicker input icon no longer available since activeadmin v1.1

### DIFF
--- a/app/assets/stylesheets/formadmin/components/_form.scss
+++ b/app/assets/stylesheets/formadmin/components/_form.scss
@@ -345,7 +345,6 @@ form.filter_form {
       }
 
       input[type='text'] {
-        background-image: asset-url('active_admin/datepicker/datepicker-input-icon.png');
         background-position: 100% 3px;
         background-repeat: no-repeat;
         padding-right: 25px;


### PR DESCRIPTION
Fix for issue #18 

The image was removed in activeadmin v1.1 and hasn't replaced for anything yet. 

Another possible fix would be to include the image in the assets folder but according to [this](https://github.com/activeadmin/activeadmin/pull/4988) activeadmin pull request the idea was that it "should be stripped of anything outdated and to simplify" and "A new PR can decide some icons we like as a default theme that would be consistent and make sure they are easy to configure/change".

So I feel removing it is the best choice.

## Before
![image](https://user-images.githubusercontent.com/15196342/31511696-ea9e8dba-af5e-11e7-8a7c-a915b99500e0.png)
That is with activeadmin < 1.1, with 1.1 it looks just like the after but it throws the error documented in the issue.

## After
![image](https://user-images.githubusercontent.com/15196342/31511801-33956e80-af5f-11e7-941b-d50e3426068f.png)

